### PR TITLE
Fix some elements' groupBlock, cpkHexColor and some inconsistencies (fix #12)

### DIFF
--- a/data.csv
+++ b/data.csv
@@ -103,17 +103,17 @@ atomicNumber, symbol, name, atomicMass, cpkHexColor, electronicConfiguration, el
 102, No , Nobelium, [259],BD0D87,[Rn] 5f14 7s2 ,1.3,,,,642,,"2, 3",,,1100,,,actinoid,1957
 103, Lr , Lawrencium, [262],C70066,[Rn] 5f14 7s2 7p1 ,1.3,,,,,,3,,,1900,,,transition metal,1961
 104, Rf , Rutherfordium, [267],CC0059,[Rn] 5f14 6d2 7s2 ,,,,,,,4,,,,,,transition metal,1969
-105, Db , Dubnium, [268],D1004F,[Rn].5f14.6d3.7s2 ,,,,,,,,,,,,,transition metal,1967
-106, Sg , Seaborgium, [271],D90045,[Rn].5f14.6d4.7s2 ,,,,,,,,,,,,,transition metal,1974
-107, Bh , Bohrium, [272],E00038,[Rn].5f14.6d5.7s2 ,,,,,,,,,,,,,transition metal,1976
-108, Hs , Hassium, [270],E6002E,[Rn].5f14.6d6.7s2 ,,,,,,,,,,,,,transition metal,1984
-109, Mt , Meitnerium, [276],EB0026,[Rn].5f14.6d7.7s2 ,,,,,,,,,,,,,transition metal,1982
-110, Ds , Darmstadtium, [281],,[Rn].5f14.6d9.7s1 ,,,,,,,,,,,,,transition metal,1994
-111, Rg , Roentgenium, [280],,[Rn].5f14.6d10.7s1 ,,,,,,,,,,,,,transition metal,1994
-112, Cn , Copernicium, [285],,[Rn].5f14.6d10.7s2 ,,,,,,,,,,,,,transition metal,1996
-113, Nh , Nihonium, [284],,[Rn].5f14.6d10.7s2.7p1 ,,,,,,,,,,,,,post-transition metal,2003
-114, Fl , Flerovium, [289],,[Rn].5f14.6d10.7s2.7p2 ,,,,,,,,,,,,,post-transition metal,1998
-115, Mc , Moscovium, [288],,[Rn].5f14.6d10.7s2.7p3 ,,,,,,,,,,,,,post-transition metal,2003
-116, Lv , Livermorium, [293],,[Rn].5f14.6d10.7s2.7p4 ,,,,,,,,,,,,,post-transition metal,2000
-117, Ts , Tennessine, [294],,[Rn].5f14.6d10.7s2.7p5 ,,,,,,,,,,,,,post-transition metal,2010
-118, Og , Oganesson, [294] ,,[Rn].5f14.6d10.7s2.7p6 ,,,,,,,,,,,,,noble gas,2002
+105, Db , Dubnium, [268],D1004F,[Rn].5f14 6d3 7s2 ,,,,,,,,,,,,,transition metal,1967
+106, Sg , Seaborgium, [271],D90045,[Rn] 5f14 6d4 7s2 ,,,,,,,,,,,,,transition metal,1974
+107, Bh , Bohrium, [272],E00038,[Rn] 5f14 6d5 7s2 ,,,,,,,,,,,,,transition metal,1976
+108, Hs , Hassium, [270],E6002E,[Rn] 5f14 6d6 7s2 ,,,,,,,,,,,,,transition metal,1984
+109, Mt , Meitnerium, [276],EB0026,[Rn] 5f14 6d7 7s2 ,,,,,,,,,,,,,transition metal,1982
+110, Ds , Darmstadtium, [281],,[Rn] 5f14 6d9 7s1 ,,,,,,,,,,,,,transition metal,1994
+111, Rg , Roentgenium, [280],,[Rn] 5f14 6d10 7s1 ,,,,,,,,,,,,,transition metal,1994
+112, Cn , Copernicium, [285],,[Rn] 5f14 6d10 7s2 ,,,,,,,,,,,,,transition metal,1996
+113, Nh , Nihonium, [284],,[Rn] 5f14 6d10 7s2 7p1 ,,,,,,,,,,,,,post-transition metal,2003
+114, Fl , Flerovium, [289],,[Rn] 5f14 6d10 7s2 7p2 ,,,,,,,,,,,,,post-transition metal,1998
+115, Mc , Moscovium, [288],,[Rn] 5f14 6d10 7s2 7p3 ,,,,,,,,,,,,,post-transition metal,2003
+116, Lv , Livermorium, [293],,[Rn] 5f14 6d10 7s2 7p4 ,,,,,,,,,,,,,post-transition metal,2000
+117, Ts , Tennessine, [294],,[Rn] 5f14 6d10 7s2 7p5 ,,,,,,,,,,,,,post-transition metal,2010
+118, Og , Oganesson, [294] ,,[Rn] 5f14 6d10 7s2 7p6 ,,,,,,,,,,,,,noble gas,2002

--- a/data.csv
+++ b/data.csv
@@ -7,7 +7,7 @@ atomicNumber, symbol, name, atomicMass, cpkHexColor, electronicConfiguration, el
 6, C , Carbon, 12.0107(8),909090,[He] 2s2 2p2 ,2.55,77,16 (+4),170,1087,-154,"-4, -3, -2, -1, 1, 2, 3, 4",solid,covalent network,3823,4300,2.26,nonmetal,Ancient
 7, N , Nitrogen, 14.0067(2),3050F8,[He] 2s2 2p3 ,3.04,75,146 (-3),155,1402,-7,"-3, -2, -1, 1, 2, 3, 4, 5",gas,diatomic,63,77,0.001251,nonmetal,1772
 8, O , Oxygen, 15.9994(3),FF0D0D,[He] 2s2 2p4 ,3.44,73,140 (-2),152,1314,-141,"-2, -1, 1, 2",gas,diatomic,55,90,0.001429,nonmetal,1774
-9, F , Fluorine, 18.9984032(5),9.00E+51,[He] 2s2 2p5 ,3.98,71,133 (-1),147,1681,-328,-1,gas,atomic,54,85,0.001696,halogen,1670
+9, F , Fluorine, 18.9984032(5),90E050,[He] 2s2 2p5 ,3.98,71,133 (-1),147,1681,-328,-1,gas,atomic,54,85,0.001696,halogen,1670
 10, Ne , Neon, 20.1797(6),B3E3F5,[He] 2s2 2p6 ,,69,,154,2081,0,,gas,atomic,25,27,0.0009,noble gas,1898
 11, Na , Sodium, 22.98976928(2),AB5CF2,[Ne] 3s1 ,0.93,154,102 (+1),227,496,-53,"-1, 1",solid,metallic,371,1156,0.968,alkali metal,1807
 12, Mg , Magnesium, 24.3050(6),8AFF00,[Ne] 3s2 ,1.31,130,72 (+2),173,738,0,"1, 2",solid,metallic,923,1363,1.738,alkaline earth metal,1808

--- a/data.csv
+++ b/data.csv
@@ -103,7 +103,7 @@ atomicNumber, symbol, name, atomicMass, cpkHexColor, electronicConfiguration, el
 102, No , Nobelium, [259],BD0D87,[Rn] 5f14 7s2 ,1.3,,,,642,,"2, 3",,,1100,,,actinoid,1957
 103, Lr , Lawrencium, [262],C70066,[Rn] 5f14 7s2 7p1 ,1.3,,,,,,3,,,1900,,,transition metal,1961
 104, Rf , Rutherfordium, [267],CC0059,[Rn] 5f14 6d2 7s2 ,,,,,,,4,,,,,,transition metal,1969
-105, Db , Dubnium, [268],D1004F,[Rn].5f14 6d3 7s2 ,,,,,,,,,,,,,transition metal,1967
+105, Db , Dubnium, [268],D1004F,[Rn] 5f14 6d3 7s2 ,,,,,,,,,,,,,transition metal,1967
 106, Sg , Seaborgium, [271],D90045,[Rn] 5f14 6d4 7s2 ,,,,,,,,,,,,,transition metal,1974
 107, Bh , Bohrium, [272],E00038,[Rn] 5f14 6d5 7s2 ,,,,,,,,,,,,,transition metal,1976
 108, Hs , Hassium, [270],E6002E,[Rn] 5f14 6d6 7s2 ,,,,,,,,,,,,,transition metal,1984

--- a/data.csv
+++ b/data.csv
@@ -116,4 +116,4 @@ atomicNumber, symbol, name, atomicMass, cpkHexColor, electronicConfiguration, el
 115, Mc , Moscovium, [288],,[Rn].5f14.6d10.7s2.7p3 ,,,,,,,,,,,,,post-transition metal,2003
 116, Lv , Livermorium, [293],,[Rn].5f14.6d10.7s2.7p4 ,,,,,,,,,,,,,post-transition metal,2000
 117, Ts , Tennessine, [294],,[Rn].5f14.6d10.7s2.7p5 ,,,,,,,,,,,,,post-transition metal,2010
-118, Og , Oganesson, [294] ,,[Rn].5f14.6d10.7s2.7p6 ,,,,,,,,,,N/A             ,N/A             ,,noble gas,2002
+118, Og , Oganesson, [294] ,,[Rn].5f14.6d10.7s2.7p6 ,,,,,,,,,,,,,noble gas,2002

--- a/data.csv
+++ b/data.csv
@@ -69,7 +69,7 @@ atomicNumber, symbol, name, atomicMass, cpkHexColor, electronicConfiguration, el
 68, Er , Erbium, 167.259(3),0.00E+00,[Xe] 4f12 6s2 ,1.24,,89 (+3),,589,-50,3,solid,metallic,1770,3141,9.066,lanthanoid,1842
 69, Tm , Thulium, 168.93421(2),00D452,[Xe] 4f13 6s2 ,1.25,,103 (+2),,597,-50,"2, 3",solid,metallic,1818,2223,9.321,lanthanoid,1879
 70, Yb , Ytterbium, 173.054(5),00BF38,[Xe] 4f14 6s2 ,1.1,,102 (+2),,603,-50,"2, 3",solid,metallic,1092,1469,6.57,lanthanoid,1878
-71, Lu , Lutetium, 174.9668(1),00AB24,[Xe] 4f14 5d1 6s2 ,1.27,160,86.1 (+3),,524,-50,3,solid,metallic,1936,3675,9.841,transition metal,1907
+71, Lu , Lutetium, 174.9668(1),00AB24,[Xe] 4f14 5d1 6s2 ,1.27,160,86.1 (+3),,524,-50,3,solid,metallic,1936,3675,9.841,lanthanoid,1907
 72, Hf , Hafnium, 178.49(2),4DC2FF,[Xe] 4f14 5d2 6s2 ,1.3,150,71 (+4),,659,0,"2, 3, 4",solid,metallic,2506,4876,13.31,transition metal,1923
 73, Ta , Tantalum, 180.94788(2),4DA6FF,[Xe] 4f14 5d3 6s2 ,1.5,138,72 (+3),,761,-31,"-1, 2, 3, 4, 5",solid,metallic,3290,5731,16.65,transition metal,1802
 74, W , Tungsten, 183.84(1),2194D6,[Xe] 4f14 5d4 6s2 ,2.36,146,66 (+4),,770,-79,"-2, -1, 1, 2, 3, 4, 5, 6",solid,metallic,3695,5828,19.25,transition metal,1783
@@ -111,9 +111,9 @@ atomicNumber, symbol, name, atomicMass, cpkHexColor, electronicConfiguration, el
 110, Ds , Darmstadtium, [281],,[Rn].5f14.6d9.7s1 ,,,,,,,,,,,,,transition metal,1994
 111, Rg , Roentgenium, [280],,[Rn].5f14.6d10.7s1 ,,,,,,,,,,,,,transition metal,1994
 112, Cn , Copernicium, [285],,[Rn].5f14.6d10.7s2 ,,,,,,,,,,,,,transition metal,1996
-113, Nh , Nihonium, [284],,[Rn].5f14.6d10.7s2.7p1 ,,,,,,,,,,,,,metal,2003
-114, Fl , Flerovium, [289],,[Rn].5f14.6d10.7s2.7p2 ,,,,,,,,,,,,,metal,1998
-115, Mc , Moscovium, [288],,[Rn].5f14.6d10.7s2.7p3 ,,,,,,,,,,,,,halogen,2003
-116, Lv , Livermorium, [293],,[Rn].5f14.6d10.7s2.7p4 ,,,,,,,,,,,,,noble gas,2000
-117, Ts , Tennessine, [294],,[Rn].5f14.6d10.7s2.7p5 ,,,,,,,,,,,,,alkali metal,2010
-118, Og , Oganesson, [294] ,,[Rn].5f14.6d10.7s2.7p6 ,,,,,,,,,,N/A             ,N/A             ,,alkaline earth metal,2002
+113, Nh , Nihonium, [284],,[Rn].5f14.6d10.7s2.7p1 ,,,,,,,,,,,,,post-transition metal,2003
+114, Fl , Flerovium, [289],,[Rn].5f14.6d10.7s2.7p2 ,,,,,,,,,,,,,post-transition metal,1998
+115, Mc , Moscovium, [288],,[Rn].5f14.6d10.7s2.7p3 ,,,,,,,,,,,,,post-transition metal,2003
+116, Lv , Livermorium, [293],,[Rn].5f14.6d10.7s2.7p4 ,,,,,,,,,,,,,post-transition metal,2000
+117, Ts , Tennessine, [294],,[Rn].5f14.6d10.7s2.7p5 ,,,,,,,,,,,,,post-transition metal,2010
+118, Og , Oganesson, [294] ,,[Rn].5f14.6d10.7s2.7p6 ,,,,,,,,,,N/A             ,N/A             ,,noble gas,2002


### PR DESCRIPTION
As discussed in issue: #12, I found a few places where I could correct some information.
I found a few other things along the way, I hope it's okay to include them in this PR.

### groupBlock
I've updated the groupBlock value for the following elements: 
- [Lutetium](https://en.wikipedia.org/wiki/Lutetium)
- [Nihonium](https://en.wikipedia.org/wiki/Nihonium)
- [Flerovium](https://en.wikipedia.org/wiki/Flerovium)
- [Moscovium](https://en.wikipedia.org/wiki/Moscovium)
- [Livermorium](https://en.wikipedia.org/wiki/Livermorium)
- [Tennessine](https://en.wikipedia.org/wiki/Tennessine)
- [Oganesson](https://en.wikipedia.org/wiki/Oganesson)

### cpkHexColor
The `cpkHexColor` for Fluorine (9) has been changed from `9.00E+51` to `90E050`
[Reference](http://jmol.sourceforge.net/jscolors/#color_F)

### Miscellaneous
- The electron configuration formatting for elements 1-104 use a single space as delimiter.
Elements 105-118 were formatted with `.`'s. I have changed that to single spaces.
E.g. `[Rn].5f14.6d4.7s2` -> `[Rn] 5f14 6d4 7s2`
- Two of Oganesson's values were `N/A` instead of an empty entry.

Thanks for reading 😄 